### PR TITLE
fix: correct npx command and add files to package.json

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ The example application showcases a simple To-Do list, demonstrating core concep
 You can create a new Boba application using `npx`.
 
 ```bash
-npx github:sholtomaud/boba-templater create-boba-app <your-app-name>
+npx github:sholtomaud/boba create-boba-app <your-app-name>
 ```
 
 This will create a new directory called `<your-app-name>` with a new Boba project.

--- a/package.json
+++ b/package.json
@@ -6,6 +6,23 @@
   "bin": {
     "create-boba-app": "bin/create-boba-app.js"
   },
+  "files": [
+    "bin",
+    "src",
+    ".github",
+    ".gitignore",
+    ".prettierrc.cjs",
+    "404.html",
+    "AGENTS.md",
+    "eslint.config.js",
+    "index.html",
+    "package.json",
+    "tsconfig.json",
+    "tsconfig.node.json",
+    "vite-plugin-component-manifest.ts",
+    "vite.config.ts",
+    "vitest.config.ts"
+  ],
   "homepage": "https://sholtomaud.github.io/boba/",
   "scripts": {
     "dev": "NODE_ENV=development vite",


### PR DESCRIPTION
This commit addresses two issues:
1. The `npx` command in `README.md` had an incorrect repository name. This has been corrected.
2. The CLI was failing when run with `npx` because `npm` was not including dotfiles like `.gitignore` in the packaged version. This has been fixed by adding a `files` array to `package.json` to explicitly include all necessary project files.